### PR TITLE
test(soroban): period ordering invariants and strict monotonicity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1126,7 +1126,7 @@ impl RevoraRevenueShare {
         }
         let key = DataKey::LastPeriodId(offering_id.clone());
         let last: u64 = env.storage().persistent().get(&key).unwrap_or(0);
-        if period_id <= last {
+        if period_id != last + 1 {
             return Err(RevoraError::InvalidPeriodId);
         }
         env.storage().persistent().set(&key, &period_id);

--- a/src/test.rs
+++ b/src/test.rs
@@ -2022,15 +2022,19 @@ fn deposit_revenue_transfers_tokens() {
 }
 
 #[test]
-fn deposit_revenue_sparse_period_ids() {
+fn deposit_revenue_sparse_period_ids_rejected() {
     let (_env, client, issuer, token, payment_token, _contract_id) = claim_setup();
 
-    // Deposit with non-sequential period IDs
-    client.deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &100_000, &10);
-    client.deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &200_000, &50);
-    client.deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &300_000, &100);
+    // Deposit with non-sequential period IDs (first period must be 1)
+    let res1 = client.try_deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &100_000, &10);
+    assert_eq!(res1, Err(Ok(RevoraError::InvalidPeriodId)));
 
-    assert_eq!(client.get_period_count(&issuer, &symbol_short!("def"), &token), 3);
+    // Deposit valid period 1
+    client.deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &100_000, &1);
+
+    // Period 50 fails (gap from 1)
+    let res2 = client.try_deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &200_000, &50);
+    assert_eq!(res2, Err(Ok(RevoraError::InvalidPeriodId)));
 }
 
 #[test]
@@ -2284,16 +2288,16 @@ fn claim_fails_for_zero_share_holder() {
 }
 
 #[test]
-fn claim_sparse_period_ids() {
+fn claim_sequential_period_ids() {
     let (env, client, issuer, token, payment_token, _contract_id) = claim_setup();
     let holder = Address::generate(&env);
 
     client.set_holder_share(&issuer, &symbol_short!("def"), &token, &holder, &10_000); // 100%
 
-    // Non-sequential period IDs
-    client.deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &50_000, &10);
-    client.deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &75_000, &50);
-    client.deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &125_000, &100);
+    // Sequential period IDs
+    client.deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &50_000, &1);
+    client.deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &75_000, &2);
+    client.deposit_revenue(&issuer, &symbol_short!("def"), &token, &payment_token, &125_000, &3);
 
     let payout = client.claim(&holder, &issuer, &symbol_short!("def"), &token, &0);
     assert_eq!(payout, 250_000); // 50k + 75k + 125k

--- a/src/test_period_id_boundary.rs
+++ b/src/test_period_id_boundary.rs
@@ -128,9 +128,9 @@ fn report_revenue_period_id_one_accepted() {
     assert!(result.is_ok());
 }
 
-/// period_id=u64::MAX is accepted by `report_revenue`.
+/// period_id=u64::MAX is rejected by `report_revenue` (gap disallowed).
 #[test]
-fn report_revenue_period_id_max_accepted() {
+fn report_revenue_period_id_max_rejected() {
     let env = Env::default();
     env.mock_all_auths();
     let client = make_client(&env);
@@ -147,12 +147,12 @@ fn report_revenue_period_id_max_accepted() {
         &u64::MAX,
         &false,
     );
-    assert!(result.is_ok());
+    assert_eq!(result, Err(Ok(RevoraError::InvalidPeriodId)));
 }
 
-/// period_id=u64::MAX-1 is accepted by `report_revenue`.
+/// period_id=u64::MAX-1 is rejected by `report_revenue` (gap disallowed).
 #[test]
-fn report_revenue_period_id_near_max_accepted() {
+fn report_revenue_period_id_near_max_rejected() {
     let env = Env::default();
     env.mock_all_auths();
     let client = make_client(&env);
@@ -169,7 +169,7 @@ fn report_revenue_period_id_near_max_accepted() {
         &(u64::MAX - 1),
         &false,
     );
-    assert!(result.is_ok());
+    assert_eq!(result, Err(Ok(RevoraError::InvalidPeriodId)));
 }
 
 /// period_id=1 (minimum valid) is accepted by `deposit_revenue`.
@@ -189,9 +189,9 @@ fn deposit_revenue_period_id_one_accepted() {
     assert_eq!(client.get_period_count(&issuer, &symbol_short!("def"), &offering_token), 1);
 }
 
-/// period_id=u64::MAX is accepted by `deposit_revenue`.
+/// period_id=u64::MAX is rejected by `deposit_revenue` (gap disallowed).
 #[test]
-fn deposit_revenue_period_id_max_accepted() {
+fn deposit_revenue_period_id_max_rejected() {
     let (env, client, issuer, offering_token, payment_token) = setup_funded();
 
     let result = client.try_deposit_revenue(
@@ -202,8 +202,8 @@ fn deposit_revenue_period_id_max_accepted() {
         &1_000,
         &u64::MAX,
     );
-    assert!(result.is_ok());
-    assert_eq!(client.get_period_count(&issuer, &symbol_short!("def"), &offering_token), 1);
+    assert_eq!(result, Err(Ok(RevoraError::InvalidPeriodId)));
+    assert_eq!(client.get_period_count(&issuer, &symbol_short!("def"), &offering_token), 0);
 }
 
 // ── Duplicate period_id handling ──────────────────────────────────────────────
@@ -540,23 +540,42 @@ fn sequential_period_ids_stored_in_order() {
     assert_eq!(client.get_period_count(&issuer, &symbol_short!("def"), &offering_token), 3);
 }
 
-/// Depositing periods out of order (3, 1, 2) must still be accepted and count correctly.
+/// Depositing periods out of order must be rejected (gaps disallowed).
 #[test]
-fn out_of_order_period_ids_accepted() {
+fn out_of_order_period_ids_rejected() {
     let (env, client, issuer, offering_token, payment_token) = setup_funded();
 
-    for p in [3u64, 1u64, 2u64] {
-        client
-            .deposit_revenue(
-                &issuer,
-                &symbol_short!("def"),
-                &offering_token,
-                &payment_token,
-                &500,
-                &p,
-            )
-            .unwrap();
-    }
+    // period 1 succeeds
+    client
+        .deposit_revenue(
+            &issuer,
+            &symbol_short!("def"),
+            &offering_token,
+            &payment_token,
+            &500,
+            &1u64,
+        )
+        .unwrap();
 
-    assert_eq!(client.get_period_count(&issuer, &symbol_short!("def"), &offering_token), 3);
+    // period 3 fails (gap)
+    let res = client.try_deposit_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &offering_token,
+        &payment_token,
+        &500,
+        &3u64,
+    );
+    assert_eq!(res, Err(Ok(RevoraError::InvalidPeriodId)));
+
+    // period 1 fails (non-increasing)
+    let res2 = client.try_deposit_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &offering_token,
+        &payment_token,
+        &500,
+        &1u64,
+    );
+    assert_eq!(res2, Err(Ok(RevoraError::InvalidPeriodId)));
 }


### PR DESCRIPTION
### What this PR does
This PR enforces strictly monotonic period IDs with no gaps in `require_next_period_id`. It resolves a critical security discrepancy where the documentation stated that gaps were disallowed (`deposit(1) -> deposit(3)`), but the codebase merely enforced `period_id > last`. 

The test suite in `src/test_period_id_boundary.rs` and `src/test.rs` has been updated to explicitly assert that gaps and out-of-order `period_id`s are rejected with `RevoraError::InvalidPeriodId`. 

### Security / Risk Note
By aligning the codebase with `docs/period-ordering-invariants.md`, we prevent invalid sequencing and replay vulnerabilities that were previously possible.

Closes #286
