### PR TITLE
feat: add duplicate offering prevention logic and documentation (#294)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Offering Token (Address)
 
 **Integration notes:**
 - Offerings are **immutable** after registration
-- No duplicate prevention; same (issuer, token) can be registered multiple times with different indices
+- **Duplicate prevention:** Registration is idempotent; re-registering the same `(issuer, namespace, token)` is a no-op that returns `Ok(())`, preserving the original registration's parameters.
 - Off-chain systems should track registration events to build offering directories
 
 ---

--- a/docs/offering-duplicate-prevention.md
+++ b/docs/offering-duplicate-prevention.md
@@ -19,11 +19,9 @@ Prevents:
 - Replay-style abuse
 
 ## Implementation Details
-Duplicate detection is performed using:
+`env.storage().persistent().has(&DataKey::OfferingIssuer(offering_id))`
 
-`get_offering(env, issuer, namespace, token)`
-
-If an existing offering is found, storage write is skipped.
+This O(1) check ensures that any logical duplicate (same issuer, namespace, and token) is detected before any storage writes occur.
 
 ## Testing
 - Existing test suite is preserved

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ use soroban_sdk::{
 // Issue #109 — Revenue report correction workflow with audit trail.
 // Placeholder branch for upstream PR scaffolding; full implementation in follow-up.
 
+#[cfg(test)]
+mod test_duplicates;
+
 /// Centralized contract error codes. Auth failures are signaled by host panic (require_auth).
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
@@ -1309,6 +1312,18 @@ impl RevoraRevenueShare {
             return Err(RevoraError::InvalidRevenueShareBps);
         }
 
+        let offering_id = OfferingId {
+            issuer: issuer.clone(),
+            namespace: namespace.clone(),
+            token: token.clone(),
+        };
+
+        // Duplicate prevention: check if offering already exists by its stable identity (issuer+namespace+token)
+        // This makes register_offering idempotent and prevents state inconsistencies in off-chain catalogs.
+        if env.storage().persistent().has(&DataKey::OfferingIssuer(offering_id.clone())) {
+            return Ok(());
+        }
+
         // Register namespace for issuer if not already present
         let ns_reg_key = DataKey2::NamespaceRegistered(issuer.clone(), namespace.clone());
         if !env.storage().persistent().has(&ns_reg_key) {
@@ -1336,12 +1351,7 @@ impl RevoraRevenueShare {
         let item_key = DataKey::OfferItem(tenant_id.clone(), count);
         env.storage().persistent().set(&item_key, &offering);
         env.storage().persistent().set(&count_key, &(count + 1));
-
-        let offering_id = OfferingId {
-            issuer: issuer.clone(),
-            namespace: namespace.clone(),
-            token: token.clone(),
-        };
+        
         let issuer_lookup_key = DataKey::OfferingIssuer(offering_id.clone());
         env.storage().persistent().set(&issuer_lookup_key, &issuer);
 

--- a/src/test_duplicates.rs
+++ b/src/test_duplicates.rs
@@ -1,0 +1,81 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::Address as _,
+    Address, Env, symbol_short,
+};
+
+fn setup_test() -> (Env, RevoraRevenueShareClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    
+    let contract_id = env.register_contract(None, RevoraRevenueShare);
+    let client = RevoraRevenueShareClient::new(&env, &contract_id);
+    
+    let admin = Address::generate(&env);
+    client.initialize(&admin, &None, &None);
+    
+    (env, client, admin)
+}
+
+#[test]
+fn test_register_duplicate_offering_is_idempotent() {
+    let (env, client, issuer) = setup_test();
+    let token = Address::generate(&env);
+    let namespace = symbol_short!("ns");
+    let payout_asset = Address::generate(&env);
+    
+    // First registration
+    client.register_offering(&issuer, &namespace, &token, &5000, &payout_asset, &0);
+    assert_eq!(client.get_offering_count(&issuer, &namespace), 1);
+    
+    let offering1 = client.get_offering(&issuer, &namespace, &token).unwrap();
+    assert_eq!(offering1.revenue_share_bps, 5000);
+    
+    // Second registration (same identity, different bps)
+    client.register_offering(&issuer, &namespace, &token, &6000, &payout_asset, &0);
+    
+    // Count should still be 1
+    assert_eq!(client.get_offering_count(&issuer, &namespace), 1);
+    
+    // Offering parameters should NOT have changed (preserving original)
+    let offering2 = client.get_offering(&issuer, &namespace, &token).unwrap();
+    assert_eq!(offering2.revenue_share_bps, 5000);
+}
+
+#[test]
+fn test_pagination_stability_with_idempotency() {
+    let (env, client, issuer) = setup_test();
+    let namespace = symbol_short!("ns");
+    let payout_asset = Address::generate(&env);
+    
+    let token_a = Address::generate(&env);
+    let token_b = Address::generate(&env);
+    
+    // Register A, then B, then A again
+    client.register_offering(&issuer, &namespace, &token_a, &1000, &payout_asset, &0);
+    client.register_offering(&issuer, &namespace, &token_b, &2000, &payout_asset, &0);
+    client.register_offering(&issuer, &namespace, &token_a, &3000, &payout_asset, &0);
+    
+    let (offerings, _) = client.get_offerings_page(&issuer, &namespace, &0, &10);
+    
+    // Should only have 2 unique offerings in the order they were first registered
+    assert_eq!(offerings.len(), 2);
+    assert_eq!(offerings.get(0).unwrap().token, token_a);
+    assert_eq!(offerings.get(1).unwrap().token, token_b);
+}
+
+#[test]
+fn test_get_offering_matches_first_registration() {
+    let (env, client, issuer) = setup_test();
+    let token = Address::generate(&env);
+    let namespace = symbol_short!("ns");
+    let payout_asset = Address::generate(&env);
+    
+    client.register_offering(&issuer, &namespace, &token, &1000, &payout_asset, &0);
+    client.register_offering(&issuer, &namespace, &token, &2000, &payout_asset, &0);
+    
+    let offering = client.get_offering(&issuer, &namespace, &token).unwrap();
+    assert_eq!(offering.revenue_share_bps, 1000);
+}


### PR DESCRIPTION
Closes #294

---

PR #294  Duplicate Offering Prevention & Stable Identity Documentation

## Description
This PR addresses issue #294 by hardening the logic for logical offering registration and documenting the stable identity model for off-chain catalogs.

## Key Changes
- **Contract Logic**: Updated `src/lib.rs` to allow/prevent duplicates based on the `issuer + token` identity model rather than just registration indices.
- **Documentation**: Created `docs/offering-duplicate-prevention.md` to clarify how the backend indexer should handle stable identities vs. registration sequences.
- **Testing**: Added `src/test_duplicates.rs` to validate pagination stability and indexing behavior when duplicate-like offerings are present.
- **README**: Updated the offering lifecycle documentation to reflect these changes.

## Verification
- Ran `cargo test` to ensure registration logic and duplicate detection work as expected.
- Verified that the indexer-safe behavior (Issuer+Token identity) is correctly documented for the `Revora-Backend` integration.

## Related Issues
Closed PR #294 