### PR TITLE
docs(soroban): tighten get_version() and migration runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,17 @@ Auth failures (e.g. wrong signer) are signaled by host/panic, not `RevoraError`.
 
 ### Contract version and migration (#23)
 
-- **Version:** Call `get_version()` to read the current contract version (a constant, e.g. `1`). This value is bumped when storage layout or semantics change in a way that affects compatibility.
-- **Upgrade strategy:** This codebase deploys a single WASM contract; there is no in-place upgrade. Future upgrades are expected to:
+- **Version:** Call `get_version()` to read the current contract version (a constant, e.g., `4`). This value is bumped when storage layout or semantics change in a way that affects compatibility.
+- **Upgrade strategy:** This codebase deploys a single WASM contract; Soroban has no EVM-style proxy upgrade, so upgrades require deploying a new contract instance. Future upgrades follow this process:
   1. Deploy a new contract (new WASM) with a higher `CONTRACT_VERSION`.
-  2. Optionally run a one-time migration (e.g. admin or migration script) that reads state from the old contract and writes into the new one, or that emits migration-milestone events for indexers.
-  3. Indexers and frontends should use `get_version()` to detect the deployed version and handle schema/API differences.
-- **Migration milestones:** When a new version is deployed, integrators can treat the first transaction that succeeds on the new contract as a migration milestone; the contract does not currently emit a dedicated "migration" event, but event schemas may include a version field (e.g. v1 events) for consumers.
+  2. Optionally run a one-time migration (e.g., admin or migration script) that reads state from the old contract and writes into the new one, or that emits migration-milestone events for indexers.
+  3. **Re-point consumers:** Update all frontend, backend, and indexer configurations to use the new contract address. Indexers and custodial backends must:
+     - Update their contract address references.
+     - Check `get_version()` on the new contract to confirm the upgrade.
+     - Update event parsing and API handling logic if the new version introduces changes to event schemas or method signatures.
+     - Treat the first successful transaction on the new contract as the migration cutover point.
+  4. The old contract remains deployed but should be considered inactive; consumers should not interact with it post-migration.
+- **Migration milestones:** When a new version is deployed, integrators can treat the first transaction that succeeds on the new contract as a migration milestone; the contract does not currently emit a dedicated "migration" event, but event schemas may include a version field (e.g., v1 events) for consumers.
 
 ### Input parameter validation (#35)
 


### PR DESCRIPTION
Closes #283

---

## Summary

I've successfully implemented the requested changes to tighten the public migration story for the Revora-Contracts Soroban project:

### Changes Made

1. **Updated README.md Contract Version Section**:
   - Changed the example version from `1` to `4` to match the current `CONTRACT_VERSION` constant in `src/lib.rs`.
   - Expanded the upgrade strategy to explicitly document:
     - Soroban's lack of EVM-style proxy upgrades.
     - Detailed steps for re-pointing consumers (frontends, backends, indexers).
     - Specific requirements for indexers and custodial backends on cutover (update contract addresses, check `get_version()`, update parsing logic if needed).
     - Clarification that the old contract remains deployed but inactive.

2. **Verified Existing Tests**:
   - Confirmed that unit tests for `get_version()` already exist in `src/test.rs`:
     - `get_version_returns_constant_version()`: Asserts `get_version()` returns `CONTRACT_VERSION`.
     - `get_version_unchanged_after_operations()`: Ensures version remains constant across operations.
   - These tests ensure the in-code constant matches the runtime return value.

3. **Git Workflow**:
   - Created and switched to branch `feature/soroban-version-migration`.
   - Committed changes with the suggested commit message: `docs(soroban): tighten get_version() and migration runbook`.

### Validation Notes

- **Testing**: The existing test suite covers `get_version()` adequately. In a proper Rust environment with Soroban SDK installed, run `cargo test` to validate. The tests confirm `get_version()` returns the correct constant value.
- **Linting**: Run `cargo clippy` for code quality checks.
- **Documentation**: The README now provides a clear, explicit migration runbook that prevents incidents from out-of-date version docs.

### Security / Risk Note

Out-of-date version documentation poses a risk for backend listeners and indexers, potentially leading to incorrect API assumptions or event parsing failures during upgrades. By synchronizing the README with the in-code `CONTRACT_VERSION` and providing explicit cutover instructions, this change mitigates the risk of migration-related incidents.

The implementation ensures that `get_version()` serves as a reliable source of truth for version detection, and the migration strategy clearly outlines the non-proxy upgrade model specific to Soroban.