### PR TITLE
soroban-prop-concentration-limits

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@ Status: 0/6 Complete
 - [ ] check_invariants oracle: payout conservation/blacklist/concentration/pause/multisig/pagination
 - [ ] prop_period_ordering (strictly increasing)
 - [ ] prop_blacklist_enforcement (claims=0)
-- [ ] prop_concentration_limits (enforce blocks)
+- [x] prop_concentration_limits (enforce blocks)
 - [ ] prop_pagination_stability (deterministic register→paginate)
 - [ ] prop_multisig_threshold (below threshold fails)
 - [ ] prop_pause_safety (mutations panic post-pause)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2457,6 +2457,10 @@ impl RevoraRevenueShare {
         }
 
         if !Self::is_event_only(&env) {
+            env.storage().persistent().set(
+                &DataKey::CurrentConcentration(offering_id.clone()),
+                &concentration_bps,
+            );
             env.events().publish(
                 (EVENT_CONCENTRATION_REPORTED, issuer, namespace, token),
                 concentration_bps,

--- a/src/proptest_helpers.rs
+++ b/src/proptest_helpers.rs
@@ -120,6 +120,8 @@ pub enum TestOperation {
     BlacklistRemove { target_index: u8 },
     /// `set_concentration_limit(issuer, namespace, token, max_bps, enforce)`
     SetConcentrationLimit { max_bps: u32, enforce: bool },
+    /// `report_concentration(issuer, namespace, token, concentration_bps)`
+    ReportConcentration { concentration_bps: u32 },
     /// `freeze()` — admin-only global freeze
     Freeze,
     /// `set_claim_delay(issuer, namespace, token, delay_secs)`
@@ -173,6 +175,11 @@ pub fn arb_set_concentration_limit() -> impl Strategy<Value = TestOperation> {
         .prop_map(|(max_bps, enforce)| TestOperation::SetConcentrationLimit { max_bps, enforce })
 }
 
+/// Strategy for a single `ReportConcentration` operation.
+pub fn arb_report_concentration() -> impl Strategy<Value = TestOperation> {
+    arb_valid_bps().prop_map(|concentration_bps| TestOperation::ReportConcentration { concentration_bps })
+}
+
 /// Strategy for any single valid operation (uniform distribution).
 pub fn arb_any_operation() -> impl Strategy<Value = TestOperation> {
     prop_oneof![
@@ -183,6 +190,7 @@ pub fn arb_any_operation() -> impl Strategy<Value = TestOperation> {
         arb_blacklist_add(),
         arb_blacklist_remove(),
         arb_set_concentration_limit(),
+        arb_report_concentration(),
         Just(TestOperation::Freeze),
         (0u64..=3600u64).prop_map(|d| TestOperation::SetClaimDelay { delay_secs: d }),
     ]

--- a/src/test.rs
+++ b/src/test.rs
@@ -4953,20 +4953,55 @@ proptest! {
 
 /// Property: Concentration limits enforced.
 proptest! {
+    #![proptest_config(proptest::test_runner::Config { cases: 50, ..Default::default() })]
     #[test]
-    fn prop_concentration_limits(env in Env::default()) {
+    fn prop_concentration_limits(
+        env in Env::default(),
+        seq in arb_valid_operation_sequence(10),
+        enforce in any::<bool>(),
+        limit_bps in 1000u32..=5000,
+        conc_bps in 5001u32..=10_000,
+    ) {
         let client = make_client(&env);
         let issuer = Address::generate(&env);
         let ns = symbol_short!("def");
         let token = Address::generate(&env);
         
         client.register_offering(&issuer, &ns, &token, &1000, &token.clone(), &0);
-        client.set_concentration_limit(&issuer, &ns, &token.clone(), &5000, &true);
         
-        // Over limit → report_revenue fails
-        client.report_concentration(&issuer, &ns, &token.clone(), &6000);
-        let result = client.try_report_revenue(&issuer, &ns, &token, &token, &1000, &1, &false);
-        prop_assert!(result.is_err());
+        // Execute background sequence
+        for op in seq {
+            match op {
+                TestOperation::ReportRevenue { amount, period_id, override_existing } => {
+                    let _ = client.try_report_revenue(&issuer, &ns, &token, &token, &amount, &period_id, &override_existing);
+                }
+                TestOperation::SetConcentrationLimit { max_bps, enforce: e } => {
+                    let _ = client.try_set_concentration_limit(&issuer, &ns, &token, &max_bps, &e);
+                }
+                TestOperation::ReportConcentration { concentration_bps } => {
+                    let _ = client.try_report_concentration(&issuer, &ns, &token, &concentration_bps);
+                }
+                _ => {}
+            }
+        }
+        
+        // Set target configuration
+        client.set_concentration_limit(&issuer, &ns, &token.clone(), &limit_bps, &enforce);
+        
+        // Report concentration over limit
+        client.report_concentration(&issuer, &ns, &token.clone(), &conc_bps);
+        
+        // Use a definitely new period_id
+        let result = client.try_report_revenue(&issuer, &ns, &token, &token, &1000, &999_999, &false);
+        
+        if enforce {
+            prop_assert_eq!(result, Err(Ok(RevoraError::ConcentrationLimitExceeded)));
+        } else {
+            // If amount validation or other guards failed it might be another error, but ConcentrationLimitExceeded MUST NOT happen
+            if let Err(Ok(err)) = result {
+                prop_assert_ne!(err, RevoraError::ConcentrationLimitExceeded);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #253

---

This PR closes the planning gap around concentration limit property testing as outlined in TODO.md, ensuring that holder concentration caps are strictly enforced during revenue operations under realistic state transitions.

During the implementation of the property tests, a critical bug was discovered in the report_concentration function where the concentration_bps was not being persisted to storage. This bug has been addressed in this PR.

Bug Fixes
Persistence in report_concentration: Fixed a critical bug in src/lib.rs where report_concentration emitted an event but failed to persist the updated concentration value to DataKey::CurrentConcentration. Without this fix, the limit enforcement check in report_revenue would always evaluate against a default value (0), rendering the concentration guardrails ineffective.

Testing Enhancements
Proptest Strategy Expansions:
Added TestOperation::ReportConcentration to the operations enum in src/proptest_helpers.rs.
Implemented the arb_report_concentration() generator strategy and integrated it into the unified arb_any_operation() sequence generator.
Advanced Property Testing (prop_concentration_limits):
Refactored the baseline test in src/test.rs to run against randomized operational sequences (up to 10 operations) to simulate mature, dynamic offering states.
Ensures that when enforce = true, a subsequent report_revenue explicitly fails with RevoraError::ConcentrationLimitExceeded if the limit is breached.
Validates the inverse: when enforce = false, the strict concentration block does not trigger.

Documentation
Updated TODO.md to mark prop_concentration_limits as complete.
Updated property-based-invariant-tests.md to reflect the coverage of concentration enforcement.
Security Note
The tests validate that the single-holder concentration limits act as a hard guardrail against outsized influence or payouts, maintaining the invariant that no single holder can exceed max_bps (when enforced) during active revenue periods