### PR TITLE
test(soroban): listing pagination and cursor stability under stress

### DIFF
--- a/docs/offering-pagination-stability.md
+++ b/docs/offering-pagination-stability.md
@@ -35,6 +35,7 @@ The Revora Revenue Share contract provides deterministic, stable pagination for 
 
 *   **Read-Only Safety**: Paginated getters are read-only and do not mutate state. They can be safely called via `simulateTransaction` without gas costs for the user.
 *   **Immutability**: Offerings, periods, and issuers are generally append-only. Whitelist/Blacklist can be modified, but their ordering mechanisms (Address keys for Whitelist, Order Vec for Blacklist) remain stable.
+*   **Bounded Reads**: Pagination is strictly capped to `MAX_PAGE_LIMIT` (20) to prevent indexer crashes and unbounded memory consumption during iteration. A limit of `0` will default to `MAX_PAGE_LIMIT`. A limit `> 20` will be capped to `20`.
 
 ## Developer Notes
 

--- a/docs/payment-token-decimal-compatibility.md
+++ b/docs/payment-token-decimal-compatibility.md
@@ -43,6 +43,7 @@ Returns the configured decimal precision or `7` if not set.
 2. **Immutable after set**: There is no restriction on updating decimals after the fact, but changing decimals mid-offering will affect future claims inconsistently with past revenue reports. Issuers should set decimals before the first revenue report.
 3. **Overflow is safe**: All multiplications are guarded with `checked_mul`. Overflow returns `0`, preventing fund inflation but potentially causing zero payouts for extremely large amounts with low-decimal tokens.
 4. **Scope**: Decimals are per-offering, not per-asset globally. Two offerings with the same payout asset may have different decimal configurations.
+5. **Read-Side Pagination**: When computing holder shares iteratively off-chain, be aware that paginated endpoints (e.g., `get_offerings_page`, `get_blacklist_page`) are capped at a `MAX_PAGE_LIMIT` of 20 to prevent unbounded execution. Indexers fetching multiple properties must handle this cursor-based traversal safely.
 
 ## Example
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2145,6 +2145,40 @@ impl RevoraRevenueShare {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
+    /// Return a page of blacklisted addresses for an offering.
+    /// Limit capped at MAX_PAGE_LIMIT (20).
+    pub fn get_blacklist_page(
+        env: Env,
+        issuer: Address,
+        namespace: Symbol,
+        token: Address,
+        start: u32,
+        limit: u32,
+    ) -> (Vec<Address>, Option<u32>) {
+        let offering_id = OfferingId { issuer, namespace, token };
+        let order_key = DataKey::BlacklistOrder(offering_id);
+        let all: Vec<Address> = env.storage()
+            .persistent()
+            .get::<DataKey, Vec<Address>>(&order_key)
+            .unwrap_or_else(|| Vec::new(&env));
+            
+        let count = all.len();
+        let effective_limit = if limit == 0 || limit > MAX_PAGE_LIMIT { MAX_PAGE_LIMIT } else { limit };
+
+        if start >= count {
+            return (Vec::new(&env), None);
+        }
+
+        let end = core::cmp::min(start + effective_limit, count);
+        let mut results = Vec::new(&env);
+        for i in start..end {
+            results.push_back(all.get(i).unwrap());
+        }
+
+        let next_cursor = if end < count { Some(end) } else { None };
+        (results, next_cursor)
+    }
+
     /// Return the current number of blacklisted addresses for an offering.
     ///
     /// This is a cheap O(1) read of the underlying map length and can be used
@@ -2318,6 +2352,41 @@ impl RevoraRevenueShare {
             .get::<DataKey, Map<Address, bool>>(&key)
             .map(|m| m.keys())
             .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Return a page of whitelisted addresses for an offering.
+    /// Limit capped at MAX_PAGE_LIMIT (20).
+    pub fn get_whitelist_page(
+        env: Env,
+        issuer: Address,
+        namespace: Symbol,
+        token: Address,
+        start: u32,
+        limit: u32,
+    ) -> (Vec<Address>, Option<u32>) {
+        let offering_id = OfferingId { issuer, namespace, token };
+        let key = DataKey::Whitelist(offering_id);
+        let all: Vec<Address> = env.storage()
+            .persistent()
+            .get::<DataKey, Map<Address, bool>>(&key)
+            .map(|m| m.keys())
+            .unwrap_or_else(|| Vec::new(&env));
+            
+        let count = all.len();
+        let effective_limit = if limit == 0 || limit > MAX_PAGE_LIMIT { MAX_PAGE_LIMIT } else { limit };
+
+        if start >= count {
+            return (Vec::new(&env), None);
+        }
+
+        let end = core::cmp::min(start + effective_limit, count);
+        let mut results = Vec::new(&env);
+        for i in start..end {
+            results.push_back(all.get(i).unwrap());
+        }
+
+        let next_cursor = if end < count { Some(end) } else { None };
+        (results, next_cursor)
     }
 
     /// Returns `true` if whitelist enforcement is enabled for an offering.

--- a/src/test.rs
+++ b/src/test.rs
@@ -5121,6 +5121,120 @@ fn continuous_invariants_deterministic_reproducible() {
     // Existing test preserved
 }
 
+#[test]
+fn test_offerings_pagination_stress() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client(&env);
+    let issuer = Address::generate(&env);
+    let ns = symbol_short!("def");
+
+    let num_offerings = 45; // Test a number that spans multiple pages (20 + 20 + 5)
+    
+    for _ in 0..num_offerings {
+        let token = Address::generate(&env);
+        client.register_offering(&issuer, &ns, &token, &1000, &token, &0);
+    }
+
+    // 1. Verify MAX_PAGE_LIMIT enforcement
+    let (page_large, next_large) = client.get_offerings_page(&issuer, &ns, &0, &100);
+    assert_eq!(page_large.len(), 20, "Should cap at MAX_PAGE_LIMIT (20)");
+    assert_eq!(next_large, Some(20), "Next cursor should be 20");
+
+    let (page_zero, next_zero) = client.get_offerings_page(&issuer, &ns, &0, &0);
+    assert_eq!(page_zero.len(), 20, "Limit 0 should default to MAX_PAGE_LIMIT (20)");
+    
+    // 2. Full traversal
+    let mut all_offerings = Vec::new(&env);
+    let mut cursor = 0;
+    loop {
+        let (page, next) = client.get_offerings_page(&issuer, &ns, &cursor, &20);
+        for item in page {
+            all_offerings.push_back(item);
+        }
+        if let Some(n) = next {
+            cursor = n;
+        } else {
+            break;
+        }
+    }
+    assert_eq!(all_offerings.len(), num_offerings, "Should retrieve all offerings");
+}
+
+#[test]
+fn test_blacklist_pagination_stress() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client(&env);
+    let issuer = Address::generate(&env);
+    let ns = symbol_short!("def");
+    let token = Address::generate(&env);
+
+    client.register_offering(&issuer, &ns, &token, &1000, &token, &0);
+
+    let num_blacklisted = 45;
+    for _ in 0..num_blacklisted {
+        let investor = Address::generate(&env);
+        client.blacklist_add(&issuer, &issuer, &ns, &token, &investor);
+    }
+
+    // 1. Verify MAX_PAGE_LIMIT enforcement
+    let (page_large, next_large) = client.get_blacklist_page(&issuer, &ns, &token, &0, &100);
+    assert_eq!(page_large.len(), 20, "Should cap at MAX_PAGE_LIMIT (20)");
+    assert_eq!(next_large, Some(20), "Next cursor should be 20");
+
+    // 2. Full traversal
+    let mut total_retrieved = 0;
+    let mut cursor = 0;
+    loop {
+        let (page, next) = client.get_blacklist_page(&issuer, &ns, &token, &cursor, &20);
+        total_retrieved += page.len();
+        if let Some(n) = next {
+            cursor = n;
+        } else {
+            break;
+        }
+    }
+    assert_eq!(total_retrieved, num_blacklisted, "Should retrieve all blacklisted addresses");
+}
+
+#[test]
+fn test_whitelist_pagination_stress() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let client = make_client(&env);
+    let issuer = Address::generate(&env);
+    let ns = symbol_short!("def");
+    let token = Address::generate(&env);
+
+    client.register_offering(&issuer, &ns, &token, &1000, &token, &0);
+
+    let num_whitelisted = 45;
+    for _ in 0..num_whitelisted {
+        let investor = Address::generate(&env);
+        client.whitelist_add(&issuer, &issuer, &ns, &token, &investor);
+    }
+
+    // 1. Verify MAX_PAGE_LIMIT enforcement
+    let (page_large, next_large) = client.get_whitelist_page(&issuer, &ns, &token, &0, &100);
+    assert_eq!(page_large.len(), 20, "Should cap at MAX_PAGE_LIMIT (20)");
+    assert_eq!(next_large, Some(20), "Next cursor should be 20");
+
+    // 2. Full traversal
+    let mut total_retrieved = 0;
+    let mut cursor = 0;
+    loop {
+        let (page, next) = client.get_whitelist_page(&issuer, &ns, &token, &cursor, &20);
+        total_retrieved += page.len();
+        if let Some(n) = next {
+            cursor = n;
+        } else {
+            break;
+        }
+    }
+    assert_eq!(total_retrieved, num_whitelisted, "Should retrieve all whitelisted addresses");
+}
+
 // ===========================================================================
 // On-chain revenue distribution calculation (#4)
 // ===========================================================================


### PR DESCRIPTION
closes #273
- Added get_blacklist_page and get_whitelist_page for bounded reads.
- Added stress test coverage for pagination limits and deterministic stability.
- Documented read-side pagination limits and indexer edge cases in docs.