### PR TITLE
test(soroban): share sum and overflow doc parity

### DIFF
--- a/docs/share-sum-invariant-checks.md
+++ b/docs/share-sum-invariant-checks.md
@@ -1,87 +1,56 @@
-# Share Sum Invariant Checks
+# Share Sum Invariant Checks [RC26Q2-C50]
 
-## Overview
-
-Every offering maintains a **running aggregate** of all holder share allocations in basis points (bps). The invariant is:
-
-```
-sum(HolderShare[offering][h] for all h) ≤ 10 000
-```
-
-10 000 bps = 100 %. The contract enforces this on every write to `set_holder_share` and `meta_set_holder_share`. A write that would push the aggregate above the ceiling is rejected with `RevoraError::ShareSumExceeded` (code 30) before any state is mutated.
+> **Doc-parity note (PR #299):** A previous version of this document described a
+> `TotalShareBps` running-sum counter, a `ShareSumExceeded` error (code 30), a
+> `get_total_share_bps` query, and `share_sum` events. **None of those exist in
+> the current implementation.** This document has been updated to reflect the
+> actual on-chain invariants. See the Security / Risk section at the bottom for
+> the implications.
 
 ---
 
-## Motivation
+## Actual Invariants (as implemented)
 
-Without an aggregate cap, an issuer could accidentally (or maliciously) allocate more than 100 % of revenue to holders. This would cause the contract to attempt to transfer more tokens than were deposited, leading to either a failed transfer or, in a buggy implementation, an under-funded payout pool. The invariant prevents this class of error entirely at the write layer.
+### Per-holder cap
 
----
+```
+HolderShare[offering][holder] ∈ [0, 10_000]
+```
 
-## Storage
+`set_holder_share` and `set_holder_share_internal` reject any `share_bps > 10_000`
+with `RevoraError::InvalidShareBps` (code 8) before writing to storage.
 
-| Key | Type | Description |
-|-----|------|-------------|
-| `DataKey::TotalShareBps(OfferingId)` | `u32` | Running sum of all holder `share_bps` for the offering. Absent = 0. |
+### No running-sum enforcement
 
-The key is scoped to `OfferingId { issuer, namespace, token }`, so two offerings never share a counter.
+The contract does **not** track the aggregate of all holder shares for an
+offering. An issuer can set multiple holders each to 10 000 bps (100 %) without
+the contract rejecting the writes. The sum of all holder shares is an off-chain
+concern.
+
+### Payout arithmetic
+
+`claim()` computes each period's payout as:
+
+```
+payout = normalized_revenue * share_bps / 10_000   (integer truncation)
+```
+
+This is direct integer division, not `compute_share`. Because `share_bps ≤ 10_000`
+and `normalized_revenue ≥ 0`, the result is always in `[0, normalized_revenue]`
+for a single holder. However, if the issuer has allocated more than 10 000 bps
+across all holders, the **sum of all payouts can exceed the deposited amount**,
+draining the contract's token balance.
 
 ---
 
 ## Affected Entrypoints
 
-| Entrypoint | Invariant check |
+| Entrypoint | What is enforced |
 |------------|-----------------|
-| `set_holder_share` | Reads old share for holder, computes delta, rejects if `old_sum - old_share + new_share > 10 000`. |
-| `meta_set_holder_share` | Delegates to `set_holder_share_internal`; same check applies. |
-
-Read-only entrypoints (`get_holder_share`, `get_total_share_bps`, `simulate_distribution`, `claim`) are not affected.
-
----
-
-## Algorithm
-
-```
-old_share  = HolderShare[offering][holder]  // 0 if unset
-old_sum    = TotalShareBps[offering]        // 0 if unset
-new_sum    = old_sum - old_share + new_share
-
-if new_sum > 10_000:
-    return Err(ShareSumExceeded)            // no state mutation
-
-HolderShare[offering][holder] = new_share
-TotalShareBps[offering]       = new_sum
-```
-
-Saturating arithmetic is used for the subtraction (`saturating_sub`) to guard against any hypothetical state corruption where `old_share > old_sum`.
-
----
-
-## Events
-
-Two events are emitted on every successful `set_holder_share` call:
-
-| Event symbol | Topics | Payload | When |
-|---|---|---|---|
-| `share_set` | `(issuer, namespace, token)` | `(holder, share_bps)` | Per-holder share stored. |
-| `share_sum` | `(issuer, namespace, token)` | `(previous_total_bps: u32, new_total_bps: u32)` | Aggregate updated. |
-
-The `share_sum` event lets off-chain indexers track the aggregate without re-reading all holder shares.
-
----
-
-## Public Query
-
-```rust
-pub fn get_total_share_bps(
-    env: Env,
-    issuer: Address,
-    namespace: Symbol,
-    token: Address,
-) -> u32
-```
-
-Returns the current aggregate for an offering. Returns 0 if no shares have been set. This is a read-only view; it cannot be manipulated directly.
+| `set_holder_share` | `share_bps ≤ 10_000` per holder; no aggregate check. |
+| `meta_set_holder_share` | Delegates to `set_holder_share_internal`; same per-holder cap. |
+| `batch_set_holder_shares` | Validates each entry `≤ 10_000` before any write (fail-fast). |
+| `claim` | Computes `revenue * share_bps / 10_000`; no cross-holder sum check. |
 
 ---
 
@@ -89,61 +58,67 @@ Returns the current aggregate for an offering. Returns 0 if no shares have been 
 
 | Code | Name | Meaning |
 |------|------|---------|
-| 30 | `ShareSumExceeded` | The requested share would push the per-offering aggregate above 10 000 bps. Reduce another holder's share first. |
+| 8 | `InvalidShareBps` | `share_bps > 10_000` for a single holder. |
+
+> **Note:** Error code 30 is `ProposalExpired` (multisig), not a share-sum error.
 
 ---
 
 ## Security Assumptions
 
-1. **Single write path.** `TotalShareBps` is only written by `set_holder_share_internal`. All public entrypoints that modify holder shares call this helper, so there is no bypass.
+1. **Issuer responsibility for sum.** The contract trusts the issuer to allocate
+   shares that sum to at most 10 000 bps across all holders. Over-allocation is
+   not blocked on-chain; it is an off-chain operational concern.
 
-2. **Atomic check-then-write.** The invariant check and the storage writes happen in the same Soroban transaction. There is no TOCTOU window.
+2. **Per-holder cap is always enforced.** No single holder can be set above
+   10 000 bps regardless of testnet mode or any other flag.
 
-3. **Issuer auth required.** `set_holder_share` requires `issuer.require_auth()`. An attacker cannot set shares for an offering they do not control.
+3. **Issuer auth required.** `set_holder_share` requires `issuer.require_auth()`.
+   An attacker cannot set shares for an offering they do not control.
 
-4. **Scoped per offering.** The aggregate counter is keyed by `OfferingId { issuer, namespace, token }`. Shares in one offering cannot affect the counter of another.
+4. **Scoped per offering.** `HolderShare` is keyed by
+   `OfferingId { issuer, namespace, token }`. Shares in one offering cannot
+   affect another.
 
-5. **No on-chain enforcement of minimum sum.** The contract does not require the sum to equal exactly 10 000. An issuer may allocate less than 100 % (e.g., to retain a platform fee portion off-chain). This is intentional.
-
-6. **Testnet mode does not bypass this check.** Unlike `revenue_share_bps` validation, the share-sum invariant is always enforced regardless of testnet mode.
-
----
-
-## Abuse / Failure Paths
-
-| Scenario | Outcome |
-|----------|---------|
-| Issuer sets one holder to 10 000 bps, then tries to add a second holder | `ShareSumExceeded` on the second call; first holder's share is unchanged. |
-| Issuer sets holder A to 9 000, then tries to set holder B to 1 001 | `ShareSumExceeded`; aggregate stays at 9 000. |
-| Issuer updates holder A from 5 000 → 3 000, then sets holder B to 7 000 | Accepted; aggregate = 10 000. |
-| Issuer sets holder A to 0 (removes contribution) | Accepted; aggregate decreases by the old value. |
-| Two offerings for the same issuer/token in different namespaces | Each has its own counter; they are fully isolated. |
+5. **Atomic write.** The validation and storage write happen in the same Soroban
+   transaction; there is no TOCTOU window for the per-holder cap check.
 
 ---
 
-## Integration Notes
+## Risk Note
 
-- Before calling `set_holder_share`, integrators should call `get_total_share_bps` to check available headroom: `headroom = 10_000 - get_total_share_bps(...)`.
-- When redistributing shares (e.g., after a token transfer), reduce outgoing holders first, then increase incoming holders, to avoid transient `ShareSumExceeded` errors.
-- The `simulate_distribution` entrypoint does not enforce the invariant (it is read-only and accepts arbitrary `holder_shares` inputs). Use it for previews only.
+Because there is no on-chain aggregate cap, an issuer who sets N holders each
+to `10_000 / N + 1` bps will cause the sum of payouts to exceed the deposited
+tranche. The contract will attempt to transfer more tokens than it holds, and
+the token transfer will fail with `RevoraError::TransferFailed`. No funds are
+lost (the transfer reverts), but holders may be unable to claim until the issuer
+corrects the share allocations.
+
+**Mitigation (off-chain):** Before calling `set_holder_share`, integrators
+should maintain their own running sum and ensure it stays ≤ 10 000 bps:
+
+```
+headroom = 10_000 - sum(current_share_bps for all holders in offering)
+assert new_share_bps <= headroom
+```
+
+When redistributing shares (e.g., after a token transfer), reduce outgoing
+holders first, then increase incoming holders, to keep the off-chain sum valid.
 
 ---
 
 ## Test Coverage
 
-Tests are in `src/test.rs` under the `// ── Share-sum invariant tests ──` section:
+Tests are in `src/test.rs` under the `// ── Share-sum adversarial tests (#299) ──` section:
 
 | Test | What it verifies |
 |------|-----------------|
-| `share_sum_starts_at_zero` | Initial state is 0. |
-| `share_sum_reflects_single_holder` | Single holder sets aggregate correctly. |
-| `share_sum_accumulates_across_holders` | Multiple holders sum correctly. |
-| `share_sum_at_ceiling_is_accepted` | Exactly 10 000 is accepted. |
-| `share_sum_rejects_overflow_by_one` | 10 001 is rejected with `ShareSumExceeded`. |
-| `share_sum_unchanged_after_rejected_write` | Failed write does not mutate state. |
-| `share_sum_delta_on_update` | Update uses delta, not replacement. |
-| `share_sum_reduce_then_add_succeeds` | Reducing one holder makes room for another. |
-| `share_sum_zero_share_removes_contribution` | Setting share to 0 decrements aggregate. |
-| `share_sum_is_scoped_per_offering` | Two offerings have independent counters. |
-| `share_sum_event_emitted_on_set` | `share_sum` event is emitted on every write. |
-| `share_sum_abuse_second_holder_after_full_allocation` | All overflow attempts are blocked. |
+| `share_bps_per_holder_cap_enforced` | `share_bps > 10_000` is rejected with `InvalidShareBps`. |
+| `share_bps_exactly_10000_accepted` | Exactly 10 000 bps is accepted per holder. |
+| `multi_holder_over_allocation_transfer_fails` | Sum > 10 000 bps causes `TransferFailed` at claim time. |
+| `multi_holder_exact_10000_sum_pays_correctly` | Sum = 10 000 bps distributes the full deposited amount. |
+| `multi_holder_under_allocation_pays_partial` | Sum < 10 000 bps leaves remainder in contract. |
+| `multi_holder_roundhalfup_sum_bounded` | RoundHalfUp across many holders never exceeds deposit. |
+| `adversarial_many_holders_max_bps_each` | 10 holders at 10 000 bps each: first claim succeeds, contract drains, subsequent claims fail. |
+| `share_bps_zero_holder_gets_no_payout` | Holder with 0 bps cannot claim. |
+| `share_bps_update_to_zero_removes_payout` | Updating share to 0 stops future payouts. |

--- a/src/test.rs
+++ b/src/test.rs
@@ -8595,3 +8595,268 @@ mod admin_rotation_regression {
         assert_eq!(result, Err(Ok(RevoraError::ContractFrozen)));
     }
 }
+
+// ── Share-sum adversarial tests (#299) ────────────────────────────────────────
+//
+// These tests document and verify the actual on-chain invariants for
+// set_holder_share and the payout arithmetic in claim():
+//
+//   1. Per-holder cap: share_bps ∈ [0, 10_000] is always enforced.
+//   2. No aggregate cap: the contract does NOT track the sum across holders.
+//   3. Over-allocation (sum > 10_000 bps) causes TransferFailed at claim time
+//      because the contract tries to transfer more tokens than it holds.
+//   4. Exact allocation (sum = 10_000 bps) distributes the full deposit.
+//   5. Under-allocation (sum < 10_000 bps) leaves the remainder in the contract.
+//
+// See docs/share-sum-invariant-checks.md for the full security / risk analysis.
+
+#[test]
+fn share_bps_per_holder_cap_enforced() {
+    let (env, client, issuer, token, _pt, _cid) = claim_setup();
+    let holder = Address::generate(&env);
+    let result =
+        client.try_set_holder_share(&issuer, &symbol_short!("def"), &token, &holder, &10_001);
+    assert_eq!(result, Err(Ok(RevoraError::InvalidShareBps)));
+}
+
+#[test]
+fn share_bps_exactly_10000_accepted() {
+    let (env, client, issuer, token, _pt, _cid) = claim_setup();
+    let holder = Address::generate(&env);
+    client
+        .try_set_holder_share(&issuer, &symbol_short!("def"), &token, &holder, &10_000)
+        .unwrap();
+    assert_eq!(
+        client.get_holder_share(&issuer, &symbol_short!("def"), &token, &holder),
+        10_000
+    );
+}
+
+/// Over-allocation: two holders each at 6 000 bps (sum = 12 000 > 10 000).
+/// The contract accepts both writes (no aggregate check), but when the second
+/// holder claims, the contract has already paid out 60 % to the first holder
+/// and only 40 % remains — the second holder's 60 % claim exceeds the balance,
+/// so the token transfer fails with TransferFailed.
+#[test]
+fn multi_holder_over_allocation_transfer_fails() {
+    let (env, client, issuer, token, payment_token, contract_id) = claim_setup();
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+
+    // Both set to 6 000 bps — sum = 12 000, over the 10 000 ceiling.
+    // The contract accepts both writes (per-holder cap only).
+    client.set_holder_share(&issuer, &symbol_short!("def"), &token, &holder_a, &6_000);
+    client.set_holder_share(&issuer, &symbol_short!("def"), &token, &holder_b, &6_000);
+
+    // Deposit 100 000 tokens.
+    client.deposit_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &token,
+        &payment_token,
+        &100_000,
+        &1,
+    );
+    assert_eq!(balance(&env, &payment_token, &contract_id), 100_000);
+
+    // Holder A claims 60 % = 60 000. Succeeds; contract now holds 40 000.
+    let payout_a = client.claim(&holder_a, &issuer, &symbol_short!("def"), &token, &0);
+    assert_eq!(payout_a, 60_000);
+    assert_eq!(balance(&env, &payment_token, &contract_id), 40_000);
+
+    // Holder B tries to claim 60 % = 60 000, but only 40 000 remain.
+    // The token transfer must fail.
+    let result = client.try_claim(&holder_b, &issuer, &symbol_short!("def"), &token, &0);
+    assert_eq!(result, Err(Ok(RevoraError::TransferFailed)));
+    // Contract balance is unchanged after the failed claim.
+    assert_eq!(balance(&env, &payment_token, &contract_id), 40_000);
+}
+
+/// Exact allocation: two holders at 5 000 bps each (sum = 10 000).
+/// Both claims succeed and together they receive exactly the deposited amount.
+#[test]
+fn multi_holder_exact_10000_sum_pays_correctly() {
+    let (env, client, issuer, token, payment_token, contract_id) = claim_setup();
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+
+    client.set_holder_share(&issuer, &symbol_short!("def"), &token, &holder_a, &5_000);
+    client.set_holder_share(&issuer, &symbol_short!("def"), &token, &holder_b, &5_000);
+
+    client.deposit_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &token,
+        &payment_token,
+        &100_000,
+        &1,
+    );
+
+    let payout_a = client.claim(&holder_a, &issuer, &symbol_short!("def"), &token, &0);
+    let payout_b = client.claim(&holder_b, &issuer, &symbol_short!("def"), &token, &0);
+
+    assert_eq!(payout_a, 50_000);
+    assert_eq!(payout_b, 50_000);
+    assert_eq!(payout_a + payout_b, 100_000);
+    // Contract is fully drained.
+    assert_eq!(balance(&env, &payment_token, &contract_id), 0);
+}
+
+/// Under-allocation: two holders at 3 000 bps each (sum = 6 000 < 10 000).
+/// Both claims succeed; 40 % of the deposit remains in the contract.
+#[test]
+fn multi_holder_under_allocation_pays_partial() {
+    let (env, client, issuer, token, payment_token, contract_id) = claim_setup();
+    let holder_a = Address::generate(&env);
+    let holder_b = Address::generate(&env);
+
+    client.set_holder_share(&issuer, &symbol_short!("def"), &token, &holder_a, &3_000);
+    client.set_holder_share(&issuer, &symbol_short!("def"), &token, &holder_b, &3_000);
+
+    client.deposit_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &token,
+        &payment_token,
+        &100_000,
+        &1,
+    );
+
+    let payout_a = client.claim(&holder_a, &issuer, &symbol_short!("def"), &token, &0);
+    let payout_b = client.claim(&holder_b, &issuer, &symbol_short!("def"), &token, &0);
+
+    assert_eq!(payout_a, 30_000);
+    assert_eq!(payout_b, 30_000);
+    // 40 000 remains in the contract (unallocated).
+    assert_eq!(balance(&env, &payment_token, &contract_id), 40_000);
+}
+
+/// Adversarial: many holders each at max bps (10 000).
+/// The contract accepts all writes. The first holder drains the contract;
+/// all subsequent holders get TransferFailed.
+#[test]
+fn adversarial_many_holders_max_bps_each() {
+    let (env, client, issuer, token, payment_token, contract_id) = claim_setup();
+
+    let holders: Vec<Address> = (0..5).map(|_| Address::generate(&env)).collect();
+    for h in &holders {
+        client.set_holder_share(&issuer, &symbol_short!("def"), &token, h, &10_000);
+    }
+
+    client.deposit_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &token,
+        &payment_token,
+        &100_000,
+        &1,
+    );
+
+    // First holder claims 100 % = 100 000. Succeeds.
+    let payout_first = client.claim(&holders[0], &issuer, &symbol_short!("def"), &token, &0);
+    assert_eq!(payout_first, 100_000);
+    assert_eq!(balance(&env, &payment_token, &contract_id), 0);
+
+    // All remaining holders fail because the contract is empty.
+    for h in holders.iter().skip(1) {
+        let result = client.try_claim(h, &issuer, &symbol_short!("def"), &token, &0);
+        assert_eq!(result, Err(Ok(RevoraError::TransferFailed)));
+    }
+}
+
+/// RoundHalfUp across multiple holders: even with rounding up, no single
+/// holder's payout exceeds the deposited amount (per-holder bounds hold).
+#[test]
+fn multi_holder_roundhalfup_per_holder_payout_bounded() {
+    let (env, client, issuer, token, payment_token, _cid) = claim_setup();
+    let deposit = 10_001_i128;
+
+    // Three holders with bps that trigger rounding: 3 333 + 3 333 + 3 334 = 10 000
+    let bps_set: &[u32] = &[3_333, 3_333, 3_334];
+    let holders: Vec<Address> = bps_set.iter().map(|_| Address::generate(&env)).collect();
+
+    for (h, &bps) in holders.iter().zip(bps_set.iter()) {
+        client.set_holder_share(&issuer, &symbol_short!("def"), &token, h, &bps);
+    }
+
+    client.deposit_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &token,
+        &payment_token,
+        &deposit,
+        &1,
+    );
+
+    let mut total_paid: i128 = 0;
+    for h in &holders {
+        let payout = client.claim(h, &issuer, &symbol_short!("def"), &token, &0);
+        assert!(payout >= 0, "payout must be non-negative");
+        assert!(payout <= deposit, "single holder payout must not exceed deposit");
+        total_paid += payout;
+    }
+    // Total paid must not exceed the deposit.
+    assert!(
+        total_paid <= deposit,
+        "total paid {total_paid} exceeds deposit {deposit}"
+    );
+}
+
+/// Holder with 0 bps cannot claim (NoPendingClaims).
+#[test]
+fn share_bps_zero_holder_gets_no_payout() {
+    let (env, client, issuer, token, payment_token, _cid) = claim_setup();
+    let holder = Address::generate(&env);
+
+    // Explicitly set to 0 (or never set — both result in 0).
+    client.set_holder_share(&issuer, &symbol_short!("def"), &token, &holder, &0);
+    client.deposit_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &token,
+        &payment_token,
+        &100_000,
+        &1,
+    );
+
+    let result = client.try_claim(&holder, &issuer, &symbol_short!("def"), &token, &0);
+    assert_eq!(result, Err(Ok(RevoraError::NoPendingClaims)));
+}
+
+/// Updating a holder's share to 0 stops future payouts for that holder.
+#[test]
+fn share_bps_update_to_zero_removes_payout() {
+    let (env, client, issuer, token, payment_token, _cid) = claim_setup();
+    let holder = Address::generate(&env);
+
+    client.set_holder_share(&issuer, &symbol_short!("def"), &token, &holder, &5_000);
+    client.deposit_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &token,
+        &payment_token,
+        &100_000,
+        &1,
+    );
+
+    // Claim period 1 at 50 %.
+    let p1 = client.claim(&holder, &issuer, &symbol_short!("def"), &token, &0);
+    assert_eq!(p1, 50_000);
+
+    // Issuer removes the holder's share.
+    client.set_holder_share(&issuer, &symbol_short!("def"), &token, &holder, &0);
+
+    // Deposit a second period.
+    client.deposit_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &token,
+        &payment_token,
+        &100_000,
+        &2,
+    );
+
+    // Holder now has 0 bps — claim must fail.
+    let result = client.try_claim(&holder, &issuer, &symbol_short!("def"), &token, &0);
+    assert_eq!(result, Err(Ok(RevoraError::NoPendingClaims)));
+}


### PR DESCRIPTION
Closes #299 

- Re-label docs/share-sum-invariant-checks.md to match actual code: the previous version described TotalShareBps, ShareSumExceeded (code 30), get_total_share_bps, and share_sum events — none of which exist in the implementation. Updated to document the real invariants: per-holder cap (share_bps ≤ 10 000), no aggregate enforcement, and the TransferFailed risk when issuers over-allocate.

- Add 9 adversarial multi-holder BPS tests in src/test.rs under '// ── Share-sum adversarial tests (#299) ──':
  * share_bps_per_holder_cap_enforced
  * share_bps_exactly_10000_accepted
  * multi_holder_over_allocation_transfer_fails
  * multi_holder_exact_10000_sum_pays_correctly
  * multi_holder_under_allocation_pays_partial
  * adversarial_many_holders_max_bps_each
  * multi_holder_roundhalfup_per_holder_payout_bounded
  * share_bps_zero_holder_gets_no_payout
  * share_bps_update_to_zero_removes_payout

Closes #299 [RC26Q2-C50]