### PR TITLE
test: cover audit reconciliation drift and saturation

### DIFF
--- a/src/audit_summary_tests.rs
+++ b/src/audit_summary_tests.rs
@@ -46,6 +46,14 @@ fn audit_summary(
     client.get_audit_summary(issuer, &symbol_short!("def"), token).unwrap()
 }
 
+fn default_offering_id(issuer: &Address, token: &Address) -> OfferingId {
+    OfferingId {
+        issuer: issuer.clone(),
+        namespace: symbol_short!("def"),
+        token: token.clone(),
+    }
+}
+
 #[test]
 fn duplicate_report_without_override_emits_rejection_and_preserves_audit_summary() {
     let (env, contract_id, issuer, token, payout_asset) = setup_offering();
@@ -88,6 +96,90 @@ fn override_report_updates_period_and_applies_net_audit_delta() {
     assert!(reconciliation.is_consistent);
     assert_eq!(reconciliation.computed_total_revenue, 100);
     assert_eq!(reconciliation.computed_report_count, 2);
+}
+
+#[test]
+fn reconcile_tracks_multiple_overrides_and_detects_forced_summary_drift() {
+    let (env, contract_id, issuer, token, payout_asset) = setup_offering();
+    let client = RevoraRevenueShareClient::new(&env, &contract_id);
+
+    client.report_revenue(&issuer, &symbol_short!("def"), &token, &payout_asset, &100, &1, &false);
+    client.report_revenue(&issuer, &symbol_short!("def"), &token, &payout_asset, &60, &2, &false);
+    client.report_revenue(&issuer, &symbol_short!("def"), &token, &payout_asset, &40, &3, &false);
+
+    client.report_revenue(&issuer, &symbol_short!("def"), &token, &payout_asset, &150, &1, &true);
+    client.report_revenue(&issuer, &symbol_short!("def"), &token, &payout_asset, &10, &2, &true);
+    client.report_revenue(&issuer, &symbol_short!("def"), &token, &payout_asset, &40, &3, &true);
+
+    let summary = audit_summary(&client, &issuer, &token);
+    assert_eq!(summary.total_revenue, 200);
+    assert_eq!(summary.report_count, 3);
+    assert_eq!(
+        client.get_revenue_by_period(&issuer, &symbol_short!("def"), &token, &1),
+        150
+    );
+    assert_eq!(
+        client.get_revenue_by_period(&issuer, &symbol_short!("def"), &token, &2),
+        10
+    );
+    assert_eq!(
+        client.get_revenue_by_period(&issuer, &symbol_short!("def"), &token, &3),
+        40
+    );
+
+    let reconciliation = client.reconcile_audit_summary(&issuer, &symbol_short!("def"), &token);
+    assert!(reconciliation.is_consistent);
+    assert!(!reconciliation.is_saturated);
+    assert_eq!(reconciliation.stored_total_revenue, 200);
+    assert_eq!(reconciliation.stored_report_count, 3);
+    assert_eq!(reconciliation.computed_total_revenue, 200);
+    assert_eq!(reconciliation.computed_report_count, 3);
+
+    let offering_id = default_offering_id(&issuer, &token);
+    env.storage().persistent().set(
+        &DataKey::AuditSummary(offering_id),
+        &AuditSummary {
+            total_revenue: 201,
+            report_count: 4,
+        },
+    );
+
+    let drifted = client.reconcile_audit_summary(&issuer, &symbol_short!("def"), &token);
+    assert!(!drifted.is_consistent);
+    assert!(!drifted.is_saturated);
+    assert_eq!(drifted.stored_total_revenue, 201);
+    assert_eq!(drifted.stored_report_count, 4);
+    assert_eq!(drifted.computed_total_revenue, 200);
+    assert_eq!(drifted.computed_report_count, 3);
+}
+
+#[test]
+fn reconcile_marks_saturated_total_revenue() {
+    let (env, contract_id, issuer, token, payout_asset) = setup_offering();
+    let client = RevoraRevenueShareClient::new(&env, &contract_id);
+
+    client.report_revenue(
+        &issuer,
+        &symbol_short!("def"),
+        &token,
+        &payout_asset,
+        &(i128::MAX - 5),
+        &1,
+        &false,
+    );
+    client.report_revenue(&issuer, &symbol_short!("def"), &token, &payout_asset, &10, &2, &false);
+
+    let summary = audit_summary(&client, &issuer, &token);
+    assert_eq!(summary.total_revenue, i128::MAX);
+    assert_eq!(summary.report_count, 2);
+
+    let reconciliation = client.reconcile_audit_summary(&issuer, &symbol_short!("def"), &token);
+    assert_eq!(reconciliation.stored_total_revenue, i128::MAX);
+    assert_eq!(reconciliation.computed_total_revenue, i128::MAX);
+    assert_eq!(reconciliation.stored_report_count, 2);
+    assert_eq!(reconciliation.computed_report_count, 2);
+    assert!(reconciliation.is_saturated);
+    assert!(!reconciliation.is_consistent);
 }
 
 #[test]


### PR DESCRIPTION
Closes #369

---

#369 Add reconcile_audit_summary tests for saturated total_revenue and override delta drift

This branch adds focused test coverage for audit summary reconciliation behavior around revenue report overrides and saturated revenue totals.

The implementation expands src/audit_summary_tests.rs with tests that verify multiple report_revenue overrides remain correctly reflected in reconcile_audit_summary. It covers increasing overrides, decreasing overrides, and zero net delta overrides, while confirming that report_count is not incremented when an existing period is overridden.

It also adds coverage for forced audit summary drift by intentionally mutating the cached AuditSummary in test storage and asserting that reconciliation reports is_consistent == false while preserving the recomputed authoritative totals.

Finally, the branch drives reported revenue to i128 ::MAX and asserts that reconciliation returns is_saturated == true, confirming saturated total handling.